### PR TITLE
Add optional custom filename for archive command

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ dependencies {
 }
 
 shadowJar {
-    archiveFileName = 'addressbook.jar'
+    archiveFileName = 'medconnect.jar'
 }
 
 defaultTasks 'clean', 'test'

--- a/src/main/java/seedu/address/logic/commands/ArchiveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ArchiveCommand.java
@@ -15,15 +15,21 @@ public class ArchiveCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Archives the address book.\n"
             + "Example: " + COMMAND_WORD;
-    public static final String MESSAGE_SUCCESS = "Address book has been archived!";
+    public static final String MESSAGE_SUCCESS = "Address book has been archived successfully!";
     public static final String MESSAGE_FAILURE = "Address book failed to be archived. Please try again later.";
 
+    private final String filename;
+
+    public ArchiveCommand(String filename) {
+        this.filename = filename;
+    }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
+
         try {
-            model.archiveAddressBook();
+            model.archiveAddressBook(filename);
         } catch (IOException e) {
             return new CommandResult(MESSAGE_FAILURE);
         }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -75,7 +75,7 @@ public class AddressBookParser {
             return new ListCommand();
 
         case ArchiveCommand.COMMAND_WORD:
-            return new ArchiveCommand();
+            return new ArchiveCommandParser().parse(arguments);
 
         case UndoCommand.COMMAND_WORD:
             return new UndoCommand();

--- a/src/main/java/seedu/address/logic/parser/ArchiveCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ArchiveCommandParser.java
@@ -1,0 +1,24 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.logic.commands.ArchiveCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new ArchiveCommand object
+ */
+public class ArchiveCommandParser implements Parser<ArchiveCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ArchiveCommand
+     * and returns a ArchiveCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ArchiveCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        String filename = args.trim();
+        return new ArchiveCommand(filename);
+    }
+}

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -55,8 +55,10 @@ public interface Model {
 
     /**
      * Archives the address book.
+     * @param filename the name of the file to archive the address book to.
+     * @throws IOException if there was an error writing to the file.
      */
-    void archiveAddressBook() throws IOException;
+    void archiveAddressBook(String filename) throws IOException;
 
     /**
      * Undoes the previous command that modified the state or storage of the address book.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -97,14 +97,15 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void archiveAddressBook() throws IOException {
+    public void archiveAddressBook(String filename) throws IOException {
         Path source = this.getAddressBookFilePath();
+        assert source != null : "Address book file path is null";
 
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss");
         String timestamp = LocalDateTime.now().format(formatter);
-        Path destination = Paths.get(source.getParent().toString(), "archive",
-                source.getFileName().toString().replace(".json", "") + "-"
-                        + timestamp + ".json");
+        String archiveFilename = source.getFileName().toString().replace(".json", "") + "-"
+                + timestamp + "-" + filename + ".json";
+        Path destination = Paths.get(source.getParent().toString(), "archive", archiveFilename);
 
         Files.createDirectories(destination.getParent());
         Files.copy(source, destination, REPLACE_EXISTING);

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -119,7 +119,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public void archiveAddressBook() {
+        public void archiveAddressBook(String filename) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/ArchiveCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ArchiveCommandTest.java
@@ -31,7 +31,7 @@ public class ArchiveCommandTest {
         Model model = new ModelManager();
         Model expectedModel = new ModelManager();
 
-        assertCommandSuccess(new ArchiveCommand(), model, ArchiveCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ArchiveCommand(""), model, ArchiveCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
@@ -39,7 +39,7 @@ public class ArchiveCommandTest {
         Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
         Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
-        assertCommandSuccess(new ArchiveCommand(), model, ArchiveCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ArchiveCommand(""), model, ArchiveCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
@@ -47,7 +47,7 @@ public class ArchiveCommandTest {
         Model model = new ModelManagerStubThrowingIoException();
         Model expectedModel = new ModelManagerStubThrowingIoException();
 
-        assertCommandSuccess(new ArchiveCommand(), model, ArchiveCommand.MESSAGE_FAILURE, expectedModel);
+        assertCommandSuccess(new ArchiveCommand(""), model, ArchiveCommand.MESSAGE_FAILURE, expectedModel);
     }
 
     /**
@@ -55,7 +55,7 @@ public class ArchiveCommandTest {
      */
     private static class ModelManagerStubThrowingIoException extends ModelManager {
         @Override
-        public void archiveAddressBook() throws IOException {
+        public void archiveAddressBook(String filename) throws IOException {
             throw new IOException();
         }
     }


### PR DESCRIPTION
Archive command format is now: `archive [OPTIONAL_FILENAME]`.

The archive file will be generated and stored in the `data/archive` directory with the name `addressbook-[TIMESTAMP][-OPTIONAL_FILENAME].json