### PR TITLE
Add commands to load and list all archive files

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ArchiveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ArchiveCommand.java
@@ -8,7 +8,7 @@ import seedu.address.commons.core.filename.Filename;
 import seedu.address.model.Model;
 
 /**
- * Clears the address book.
+ * Archives the address book.
  */
 public class ArchiveCommand extends Command {
 

--- a/src/main/java/seedu/address/logic/commands/ListArchiveFilesCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListArchiveFilesCommand.java
@@ -13,19 +13,18 @@ import java.util.logging.Logger;
 
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.Model;
-import seedu.address.model.ModelManager;
 
 /**
  * Lists all archive files in the archive folder.
  */
 public class ListArchiveFilesCommand extends Command {
-    private static final Logger logger = LogsCenter.getLogger(ListArchiveFilesCommand.class);
-
     public static final String COMMAND_WORD = "listArchives";
 
     public static final String MESSAGE_SUCCESS = "Listed all archive files.";
     public static final String MESSAGE_NO_ARCHIVE = "No archive files found.";
     public static final String MESSAGE_FAILURE = "Failed to find archive files. Please try again later.";
+
+    private static final Logger logger = LogsCenter.getLogger(ListArchiveFilesCommand.class);
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/address/logic/commands/ListArchiveFilesCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListArchiveFilesCommand.java
@@ -36,6 +36,7 @@ public class ListArchiveFilesCommand extends Command {
 
         Path archiveDir = Paths.get(source.getParent().toString(), "archive");
         if (!Files.exists(archiveDir)) {
+            logger.info("No archive directory found.");
             return new CommandResult(MESSAGE_NO_ARCHIVE);
         }
 

--- a/src/main/java/seedu/address/logic/commands/ListArchiveFilesCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListArchiveFilesCommand.java
@@ -9,17 +9,22 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Logger;
 
+import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
 
 /**
  * Lists all archive files in the archive folder.
  */
 public class ListArchiveFilesCommand extends Command {
+    private static final Logger logger = LogsCenter.getLogger(ListArchiveFilesCommand.class);
 
     public static final String COMMAND_WORD = "listArchives";
 
     public static final String MESSAGE_SUCCESS = "Listed all archive files.";
+    public static final String MESSAGE_NO_ARCHIVE = "No archive files found.";
     public static final String MESSAGE_FAILURE = "Failed to find archive files. Please try again later.";
 
     @Override
@@ -30,6 +35,10 @@ public class ListArchiveFilesCommand extends Command {
         assert source != null : "Address book file path is null";
 
         Path archiveDir = Paths.get(source.getParent().toString(), "archive");
+        if (!Files.exists(archiveDir)) {
+            return new CommandResult(MESSAGE_NO_ARCHIVE);
+        }
+
         List<String> archiveFiles = new ArrayList<>();
 
         try (DirectoryStream<Path> stream = Files.newDirectoryStream(archiveDir, "*.json")) {
@@ -37,10 +46,17 @@ public class ListArchiveFilesCommand extends Command {
                 archiveFiles.add(entry.getFileName().toString());
             }
         } catch (IOException e) {
+            logger.severe("Failed to list archive files: " + e.getMessage());
             return new CommandResult(MESSAGE_FAILURE);
         }
 
+        if (archiveFiles.isEmpty()) {
+            return new CommandResult(MESSAGE_NO_ARCHIVE);
+        }
+
         String resultMessage = String.join("\n", archiveFiles);
+
+        logger.info("Listed all archive files.");
         return new CommandResult(MESSAGE_SUCCESS + "\n" + resultMessage);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ListArchiveFilesCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListArchiveFilesCommand.java
@@ -1,0 +1,46 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import seedu.address.model.Model;
+
+/**
+ * Lists all archive files in the archive folder.
+ */
+public class ListArchiveFilesCommand extends Command {
+
+    public static final String COMMAND_WORD = "listArchives";
+
+    public static final String MESSAGE_SUCCESS = "Listed all archive files.";
+    public static final String MESSAGE_FAILURE = "Failed to find archive files. Please try again later.";
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+
+        Path source = model.getAddressBookFilePath();
+        assert source != null : "Address book file path is null";
+
+        Path archiveDir = Paths.get(source.getParent().toString(), "archive");
+        List<String> archiveFiles = new ArrayList<>();
+
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(archiveDir, "*.json")) {
+            for (Path entry : stream) {
+                archiveFiles.add(entry.getFileName().toString());
+            }
+        } catch (IOException e) {
+            return new CommandResult(MESSAGE_FAILURE);
+        }
+
+        String resultMessage = String.join("\n", archiveFiles);
+        return new CommandResult(MESSAGE_SUCCESS + "\n" + resultMessage);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/LoadArchiveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LoadArchiveCommand.java
@@ -61,4 +61,19 @@ public class LoadArchiveCommand extends Command {
         logger.info("Loaded archive file: " + archiveFilename);
         return new CommandResult(String.format(MESSAGE_SUCCESS, archiveFilename));
     }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof LoadArchiveCommand)) {
+            return false;
+        }
+
+        LoadArchiveCommand otherDeleteCommand = (LoadArchiveCommand) other;
+        return archiveFilename.equals(otherDeleteCommand.archiveFilename);
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/LoadArchiveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LoadArchiveCommand.java
@@ -19,8 +19,6 @@ import seedu.address.storage.JsonAddressBookStorage;
  * Loads an archive file and sets it as the current address book.
  */
 public class LoadArchiveCommand extends Command {
-    private static final Logger logger = LogsCenter.getLogger(LoadArchiveCommand.class);
-
     public static final String COMMAND_WORD = "loadArchive";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Loads an archive file.\n"
             + "Parameters: FILENAME\n"
@@ -29,6 +27,8 @@ public class LoadArchiveCommand extends Command {
     public static final String MESSAGE_SUCCESS = "Loaded archive file: %1$s";
     public static final String MESSAGE_NOT_FOUND = "Archive file not found: %1$s";
     public static final String MESSAGE_FAILURE = "Failed to load archive file: %1$s";
+
+    private static final Logger logger = LogsCenter.getLogger(LoadArchiveCommand.class);
 
     private final Filename archiveFilename;
 

--- a/src/main/java/seedu/address/logic/commands/LoadArchiveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LoadArchiveCommand.java
@@ -9,6 +9,7 @@ import java.nio.file.Paths;
 import java.util.logging.Logger;
 
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.core.filename.Filename;
 import seedu.address.commons.exceptions.DataLoadingException;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
@@ -29,9 +30,9 @@ public class LoadArchiveCommand extends Command {
     public static final String MESSAGE_NOT_FOUND = "Archive file not found: %1$s";
     public static final String MESSAGE_FAILURE = "Failed to load archive file: %1$s";
 
-    private final String archiveFilename;
+    private final Filename archiveFilename;
 
-    public LoadArchiveCommand(String archiveFilename) {
+    public LoadArchiveCommand(Filename archiveFilename) {
         this.archiveFilename = archiveFilename;
     }
 
@@ -42,8 +43,9 @@ public class LoadArchiveCommand extends Command {
         Path source = model.getAddressBookFilePath();
         assert source != null : "Address book file path is null";
 
-        Path archiveFile = Paths.get(source.getParent().toString(), "archive", archiveFilename);
+        Path archiveFile = Paths.get(source.getParent().toString(), "archive", archiveFilename.toString());
         if (!Files.exists(archiveFile)) {
+            logger.info("Archive file not found: " + archiveFilename);
             return new CommandResult(String.format(MESSAGE_NOT_FOUND, archiveFilename));
         }
 

--- a/src/main/java/seedu/address/logic/commands/LoadArchiveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LoadArchiveCommand.java
@@ -1,0 +1,62 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.logging.Logger;
+
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.exceptions.DataLoadingException;
+import seedu.address.model.Model;
+import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.storage.JsonAddressBookStorage;
+
+/**
+ * Loads an archive file and sets it as the current address book.
+ */
+public class LoadArchiveCommand extends Command {
+    private static final Logger logger = LogsCenter.getLogger(LoadArchiveCommand.class);
+
+    public static final String COMMAND_WORD = "loadArchive";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Loads an archive file.\n"
+            + "Parameters: FILENAME\n"
+            + "Example: " + COMMAND_WORD + "addressbook-20241023_114324-example.json";
+
+    public static final String MESSAGE_SUCCESS = "Loaded archive file: %1$s";
+    public static final String MESSAGE_NOT_FOUND = "Archive file not found: %1$s";
+    public static final String MESSAGE_FAILURE = "Failed to load archive file: %1$s";
+
+    private final String archiveFilename;
+
+    public LoadArchiveCommand(String archiveFilename) {
+        this.archiveFilename = archiveFilename;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+
+        Path source = model.getAddressBookFilePath();
+        assert source != null : "Address book file path is null";
+
+        Path archiveFile = Paths.get(source.getParent().toString(), "archive", archiveFilename);
+        if (!Files.exists(archiveFile)) {
+            return new CommandResult(String.format(MESSAGE_NOT_FOUND, archiveFilename));
+        }
+
+        try {
+            JsonAddressBookStorage storage = new JsonAddressBookStorage(archiveFile);
+            ReadOnlyAddressBook addressBook = storage.readAddressBook().orElseThrow(IOException::new);
+            model.setAddressBook(addressBook);
+        } catch (IOException | DataLoadingException e) {
+            logger.severe("Failed to load archive file: " + e.getMessage());
+            return new CommandResult(String.format(MESSAGE_FAILURE, archiveFilename));
+        }
+
+        logger.info("Loaded archive file: " + archiveFilename);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, archiveFilename));
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -19,6 +19,7 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListArchiveFilesCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.LoadArchiveCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -80,6 +81,9 @@ public class AddressBookParser {
 
         case ListArchiveFilesCommand.COMMAND_WORD:
             return new ListArchiveFilesCommand();
+
+        case LoadArchiveCommand.COMMAND_WORD:
+            return new LoadArchiveCommandParser().parse(arguments);
 
         case UndoCommand.COMMAND_WORD:
             return new UndoCommand();

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -17,6 +17,7 @@ import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.ListArchiveFilesCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.UndoCommand;
@@ -76,6 +77,9 @@ public class AddressBookParser {
 
         case ArchiveCommand.COMMAND_WORD:
             return new ArchiveCommandParser().parse(arguments);
+
+        case ListArchiveFilesCommand.COMMAND_WORD:
+            return new ListArchiveFilesCommand();
 
         case UndoCommand.COMMAND_WORD:
             return new UndoCommand();

--- a/src/main/java/seedu/address/logic/parser/LoadArchiveCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/LoadArchiveCommandParser.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.parser;
 
 import seedu.address.commons.core.filename.Filename;
-import seedu.address.logic.commands.ArchiveCommand;
 import seedu.address.logic.commands.LoadArchiveCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 

--- a/src/main/java/seedu/address/logic/parser/LoadArchiveCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/LoadArchiveCommandParser.java
@@ -1,0 +1,23 @@
+package seedu.address.logic.parser;
+
+import seedu.address.commons.core.filename.Filename;
+import seedu.address.logic.commands.ArchiveCommand;
+import seedu.address.logic.commands.LoadArchiveCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new ArchiveCommand object
+ */
+public class LoadArchiveCommandParser implements Parser<LoadArchiveCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ArchiveCommand
+     * and returns a ArchiveCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public LoadArchiveCommand parse(String args) throws ParseException {
+        Filename filename = ParserUtil.parseFilename(args);
+        return new LoadArchiveCommand(filename);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/ArchiveCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ArchiveCommandTest.java
@@ -19,12 +19,21 @@ import seedu.address.model.UserPrefs;
 public class ArchiveCommandTest {
     @BeforeEach
     public void setUp() throws IOException {
-        FileUtil.createIfMissing(new UserPrefs().getAddressBookFilePath());
+        FileUtil.createIfMissing(new ModelManager().getAddressBookFilePath());
     }
 
     @AfterEach
     public void tearDown() throws IOException {
-        Files.deleteIfExists(new UserPrefs().getAddressBookFilePath());
+        Files.deleteIfExists(new ModelManager().getAddressBookFilePath());
+
+        // Delete all files in the archive directory
+        Files.walk(new ModelManager().getAddressBookFilePath().getParent())
+                .map(java.nio.file.Path::toFile)
+                .forEach(file -> {
+                    if (!file.delete()) {
+                        file.deleteOnExit();
+                    }
+                });
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/ListArchiveFilesCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListArchiveFilesCommandTest.java
@@ -9,6 +9,8 @@ import java.nio.file.Path;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -60,6 +62,7 @@ public class ListArchiveFilesCommandTest {
     }
 
     @Test
+    @EnabledOnOs({OS.WINDOWS, OS.LINUX})
     public void execute_withMultipleArchiveFiles_success() throws IOException {
         Files.createFile(Path.of(archiveDir.toString(), "multiple_archive1.json"));
         Files.createFile(Path.of(archiveDir.toString(), "multiple_archive2.json"));

--- a/src/test/java/seedu/address/logic/commands/ListArchiveFilesCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListArchiveFilesCommandTest.java
@@ -61,10 +61,10 @@ public class ListArchiveFilesCommandTest {
 
     @Test
     public void execute_withMultipleArchiveFiles_success() throws IOException {
-        Files.createFile(Path.of(archiveDir.toString(), "multipleArchive1.json"));
-        Files.createFile(Path.of(archiveDir.toString(), "multipleArchive2.json"));
-        String expectedMessage = ListArchiveFilesCommand.MESSAGE_SUCCESS + "\n" + "multipleArchive1.json\n"
-                + "multipleArchive2.json";
+        Files.createFile(Path.of(archiveDir.toString(), "multiple_archive1.json"));
+        Files.createFile(Path.of(archiveDir.toString(), "multiple_archive2.json"));
+        String expectedMessage = ListArchiveFilesCommand.MESSAGE_SUCCESS + "\n" + "multiple_archive1.json\n"
+                + "multiple_archive2.json";
         assertCommandSuccess(new ListArchiveFilesCommand(), modelStub, expectedMessage, modelStub);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ListArchiveFilesCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListArchiveFilesCommandTest.java
@@ -1,0 +1,70 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+
+public class ListArchiveFilesCommandTest {
+    private Path archiveDir;
+    private Model modelStub;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        modelStub = new ModelManager();
+        archiveDir = Files.createDirectories(Path.of(modelStub.getAddressBookFilePath().getParent().toString(),
+                "archive"));
+    }
+
+    @AfterEach
+    public void tearDown() throws IOException {
+        if (!Files.exists(archiveDir)) {
+            return;
+        }
+
+        Files.walk(archiveDir)
+                .map(Path::toFile)
+                .forEach(file -> {
+                    if (!file.delete()) {
+                        file.deleteOnExit();
+                    }
+                });
+    }
+
+    @Test
+    public void execute_noArchiveDirectory_success() throws IOException {
+        Files.deleteIfExists(archiveDir);
+        assertCommandSuccess(new ListArchiveFilesCommand(), modelStub, ListArchiveFilesCommand.MESSAGE_NO_ARCHIVE,
+                modelStub);
+    }
+
+    @Test
+    public void execute_noArchiveFiles_success() {
+        assertCommandSuccess(new ListArchiveFilesCommand(), modelStub, ListArchiveFilesCommand.MESSAGE_NO_ARCHIVE,
+                modelStub);
+    }
+
+    @Test
+    public void execute_withArchiveFiles_success() throws IOException {
+        Files.createFile(Path.of(archiveDir.toString(), "archive.json"));
+        String expectedMessage = ListArchiveFilesCommand.MESSAGE_SUCCESS + "\n" + "archive.json";
+        assertCommandSuccess(new ListArchiveFilesCommand(), modelStub, expectedMessage, modelStub);
+    }
+
+    @Test
+    public void execute_withMultipleArchiveFiles_success() throws IOException {
+        Files.createFile(Path.of(archiveDir.toString(), "multipleArchive1.json"));
+        Files.createFile(Path.of(archiveDir.toString(), "multipleArchive2.json"));
+        String expectedMessage = ListArchiveFilesCommand.MESSAGE_SUCCESS + "\n" + "multipleArchive1.json\n"
+                + "multipleArchive2.json";
+        assertCommandSuccess(new ListArchiveFilesCommand(), modelStub, expectedMessage, modelStub);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/ListArchiveFilesCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListArchiveFilesCommandTest.java
@@ -17,12 +17,11 @@ import seedu.address.model.ModelManager;
 
 public class ListArchiveFilesCommandTest {
     private Path archiveDir;
-    private Model modelStub;
+    private final Model model = new ModelManager();
 
     @BeforeEach
     public void setUp() throws IOException {
-        modelStub = new ModelManager();
-        archiveDir = Files.createDirectories(Path.of(modelStub.getAddressBookFilePath().getParent().toString(),
+        archiveDir = Files.createDirectories(Path.of(model.getAddressBookFilePath().getParent().toString(),
                 "archive"));
     }
 
@@ -44,21 +43,21 @@ public class ListArchiveFilesCommandTest {
     @Test
     public void execute_noArchiveDirectory_success() throws IOException {
         Files.deleteIfExists(archiveDir);
-        assertCommandSuccess(new ListArchiveFilesCommand(), modelStub, ListArchiveFilesCommand.MESSAGE_NO_ARCHIVE,
-                modelStub);
+        assertCommandSuccess(new ListArchiveFilesCommand(), model, ListArchiveFilesCommand.MESSAGE_NO_ARCHIVE,
+                model);
     }
 
     @Test
     public void execute_noArchiveFiles_success() {
-        assertCommandSuccess(new ListArchiveFilesCommand(), modelStub, ListArchiveFilesCommand.MESSAGE_NO_ARCHIVE,
-                modelStub);
+        assertCommandSuccess(new ListArchiveFilesCommand(), model, ListArchiveFilesCommand.MESSAGE_NO_ARCHIVE,
+                model);
     }
 
     @Test
     public void execute_withArchiveFiles_success() throws IOException {
         Files.createFile(Path.of(archiveDir.toString(), "archive.json"));
         String expectedMessage = ListArchiveFilesCommand.MESSAGE_SUCCESS + "\n" + "archive.json";
-        assertCommandSuccess(new ListArchiveFilesCommand(), modelStub, expectedMessage, modelStub);
+        assertCommandSuccess(new ListArchiveFilesCommand(), model, expectedMessage, model);
     }
 
     @Test
@@ -68,6 +67,6 @@ public class ListArchiveFilesCommandTest {
         Files.createFile(Path.of(archiveDir.toString(), "multiple_archive2.json"));
         String expectedMessage = ListArchiveFilesCommand.MESSAGE_SUCCESS + "\n" + "multiple_archive1.json\n"
                 + "multiple_archive2.json";
-        assertCommandSuccess(new ListArchiveFilesCommand(), modelStub, expectedMessage, modelStub);
+        assertCommandSuccess(new ListArchiveFilesCommand(), model, expectedMessage, model);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/LoadArchiveCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/LoadArchiveCommandTest.java
@@ -1,0 +1,106 @@
+package seedu.address.logic.commands;
+
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.filename.Filename;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.storage.AddressBookStorage;
+import seedu.address.storage.JsonAddressBookStorage;
+
+public class LoadArchiveCommandTest {
+    private Path archiveDir;
+    private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        archiveDir = Files.createDirectories(Path.of(model.getAddressBookFilePath().getParent().toString(),
+                "archive"));
+    }
+
+    @AfterEach
+    public void tearDown() throws IOException {
+        if (!Files.exists(archiveDir)) {
+            return;
+        }
+
+        Files.walk(archiveDir)
+                .map(Path::toFile)
+                .forEach(file -> {
+                    if (!file.delete()) {
+                        file.deleteOnExit();
+                    }
+                });
+    }
+
+    @Test
+    public void execute_archiveFileNotFound_success() throws IOException {
+        Files.deleteIfExists(archiveDir);
+        Filename filename = new Filename("no_archive.json");
+        String expectedMessage = String.format(LoadArchiveCommand.MESSAGE_NOT_FOUND, filename);
+        assertCommandSuccess(new LoadArchiveCommand(filename), model, expectedMessage, model);
+    }
+
+    @Test
+    public void execute_errorLoadingArchiveFile_failure() throws IOException {
+        // Create empty archive file
+        Filename filename = new Filename("error_archive.json");
+        Path archiveFilepath = Paths.get(archiveDir.toString(), filename.toString());
+        Files.createFile(archiveFilepath);
+
+        String expectedMessage = String.format(LoadArchiveCommand.MESSAGE_FAILURE, filename);
+        assertCommandSuccess(new LoadArchiveCommand(filename), model, expectedMessage, model);
+    }
+
+    @Test
+    public void execute_withArchiveFile_success() throws IOException {
+        // Save the current address book to a file
+        Path source = model.getAddressBookFilePath();
+        AddressBookStorage addressBookStorage = new JsonAddressBookStorage(source);
+        addressBookStorage.saveAddressBook(model.getAddressBook());
+
+        // Copy the address book file to the archive directory
+        Filename filename = new Filename("archive.json");
+        Path archiveFilepath = Paths.get(archiveDir.toString(), filename.toString());
+        Files.copy(source, archiveFilepath, REPLACE_EXISTING);
+
+        String expectedMessage = String.format(LoadArchiveCommand.MESSAGE_SUCCESS, filename);
+        assertCommandSuccess(new LoadArchiveCommand(filename), model, expectedMessage, model);
+    }
+
+    @Test
+    public void equals() {
+        LoadArchiveCommand loadArchiveFirstCommand = new LoadArchiveCommand(new Filename("test1"));
+        LoadArchiveCommand loadArchiveSecondCommand = new LoadArchiveCommand(new Filename("test2"));
+
+        // same object -> returns true
+        assertTrue(loadArchiveFirstCommand.equals(loadArchiveFirstCommand));
+
+        // same values -> returns true
+        LoadArchiveCommand loadArchiveFirstCommandCopy = new LoadArchiveCommand(new Filename("test1"));
+        assertTrue(loadArchiveFirstCommand.equals(loadArchiveFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(loadArchiveFirstCommand.equals("test1"));
+
+        // null -> returns false
+        assertFalse(loadArchiveFirstCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(loadArchiveFirstCommand.equals(loadArchiveSecondCommand));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -22,7 +22,9 @@ import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.ListArchiveFilesCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.LoadArchiveCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -94,6 +96,17 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_archive() throws Exception {
         assertTrue(parser.parseCommand(ArchiveCommand.COMMAND_WORD) instanceof ArchiveCommand);
+    }
+
+    @Test
+    public void parseCommand_listArchiveFiles() throws Exception {
+        assertTrue(parser.parseCommand(ListArchiveFilesCommand.COMMAND_WORD) instanceof ListArchiveFilesCommand);
+        assertTrue(parser.parseCommand(ListArchiveFilesCommand.COMMAND_WORD + " 3") instanceof ListArchiveFilesCommand);
+    }
+
+    @Test
+    public void parseCommand_loadArchive() throws Exception {
+        assertTrue(parser.parseCommand(LoadArchiveCommand.COMMAND_WORD) instanceof LoadArchiveCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/LoadArchiveCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/LoadArchiveCommandParserTest.java
@@ -1,0 +1,24 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.filename.Filename;
+import seedu.address.logic.commands.LoadArchiveCommand;
+
+public class LoadArchiveCommandParserTest {
+
+    private final LoadArchiveCommandParser parser = new LoadArchiveCommandParser();
+
+    @Test
+    public void parse_validArgs_returnLoadArchiveCommand() {
+        assertParseSuccess(parser, "Test", new LoadArchiveCommand(new Filename("Test")));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "/", Filename.MESSAGE_CONSTRAINTS);
+    }
+}


### PR DESCRIPTION
Closes #62 and Closes #63 

### List all archive files
Enter the command `listArchives` to list all archive filenames in the CLI.
If there are no archive files, it should return the message "No archive files found."

### Load archive file
Enter the command `loadArchive [FILENAME]` to load the respective archive file.