### PR TITLE
Find Command accepts only alphabetical keywords

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -23,6 +23,8 @@ public class Messages {
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
+    public static final String MESSAGE_INVALID_FIND_KEYWORDS =
+                "The keywords provided must only contain alphabetical characters.";
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -16,7 +16,7 @@ public class FindCommand extends Command {
     public static final String COMMAND_WORD = "find";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
-            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+            + "the specified keywords (alphabetical case-insensitive) and displays them as a list with index numbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " alice bob charlie";
 

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_FIND_KEYWORDS;
 
 import java.util.Arrays;
 
@@ -27,7 +28,14 @@ public class FindCommandParser implements Parser<FindCommand> {
 
         String[] nameKeywords = trimmedArgs.split("\\s+");
 
-        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords));
+
+        if (!predicate.isValidKeywords(trimmedArgs)) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_FIND_KEYWORDS, FindCommand.MESSAGE_USAGE));
+        }
+
+        return new FindCommand(predicate);
     }
 
 }

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -6,13 +6,23 @@ import java.util.function.Predicate;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.commons.util.ToStringBuilder;
 
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
 /**
  * Tests that a {@code Person}'s {@code Name} matches any of the keywords given.
  */
 public class NameContainsKeywordsPredicate implements Predicate<Person> {
     private final List<String> keywords;
 
+    public static final String KEYWORD_CONSTRAINTS = "Keywords should only contain alphabetical characters";
+
+    /*
+     * The keywords must only contain alphabetical characters.
+     */
+    public static final String VALIDATION_REGEX = "[\\p{Alpha}][\\p{Alpha} ]*";
+
     public NameContainsKeywordsPredicate(List<String> keywords) {
+        checkArgument(keywords.stream().allMatch(this::isValidKeyword), KEYWORD_CONSTRAINTS);
         this.keywords = keywords;
     }
 
@@ -20,6 +30,13 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
     public boolean test(Person person) {
         return keywords.stream()
                 .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword));
+    }
+
+    /*
+     * Returns true if the keyword is valid and only contains alphabetical characters.
+     */
+    public boolean isValidKeyword(String keyword) {
+        return keyword.matches(VALIDATION_REGEX);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -22,7 +22,6 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
     public static final String VALIDATION_REGEX = "[\\p{Alpha}][\\p{Alpha} ]*";
 
     public NameContainsKeywordsPredicate(List<String> keywords) {
-        checkArgument(keywords.stream().allMatch(this::isValidKeyword), KEYWORD_CONSTRAINTS);
         this.keywords = keywords;
     }
 
@@ -35,7 +34,7 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
     /*
      * Returns true if the keyword is valid and only contains alphabetical characters.
      */
-    public boolean isValidKeyword(String keyword) {
+    public boolean isValidKeywords(String keyword) {
         return keyword.matches(VALIDATION_REGEX);
     }
 

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -6,20 +6,18 @@ import java.util.function.Predicate;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.commons.util.ToStringBuilder;
 
-import static seedu.address.commons.util.AppUtil.checkArgument;
-
 /**
  * Tests that a {@code Person}'s {@code Name} matches any of the keywords given.
  */
 public class NameContainsKeywordsPredicate implements Predicate<Person> {
-    private final List<String> keywords;
-
-    public static final String KEYWORD_CONSTRAINTS = "Keywords should only contain alphabetical characters";
-
     /*
      * The keywords must only contain alphabetical characters.
      */
+    public static final String KEYWORD_CONSTRAINTS = "Keywords should only contain alphabetical characters";
+
     public static final String VALIDATION_REGEX = "[\\p{Alpha}][\\p{Alpha} ]*";
+
+    private final List<String> keywords;
 
     public NameContainsKeywordsPredicate(List<String> keywords) {
         this.keywords = keywords;

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -28,7 +28,7 @@ public class FindCommandParserTest {
         assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
+        assertParseSuccess(parser, "  Alice            Bob      ", expectedFindCommand);
     }
 
 }


### PR DESCRIPTION
Initial functionality: Find Command would work with no restrictions on keywords (Command would work with keywords that included numbers, special characters). 

However, names of Persons are restricted to only contain alphabetical characters, so Find should follow the same restrictions.

Closes #95.
