### PR TITLE
Fix spacing issue in Edit Command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -66,8 +66,8 @@ public class EditCommand extends Command {
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
-            + PREFIX_EMAIL + "johndoe@example.com"
-            + PREFIX_EMERGENCY_CONTACT_TO_EDIT + "John Kennedy"
+            + PREFIX_EMAIL + "johndoe@example.com "
+            + PREFIX_EMERGENCY_CONTACT_TO_EDIT + "John Kennedy "
             + PREFIX_EMERGENCY_CONTACT_NAME + "John Kentucky";
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";


### PR DESCRIPTION
Example command for Edit Command fixed to show proper spacing between parameters.
Closes #98.