### PR TITLE
Fix Emergency Contact Card UI bugs

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddEmergencyContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddEmergencyContactCommand.java
@@ -36,7 +36,7 @@ public class AddEmergencyContactCommand extends Command {
             + "Parameters: INDEX (must be a positive integer) "
             + PREFIX_EMERGENCY_CONTACT_NAME + "EMERGENCY CONTACT NAME "
             + PREFIX_EMERGENCY_CONTACT_PHONE + "EMERGENCY CONTACT PHONE "
-            + PREFIX_EMERGENCY_CONTACT_RELATIONSHIP + "EMERGENCY CONTACT RELATIONSHIP "
+            + PREFIX_EMERGENCY_CONTACT_RELATIONSHIP + "EMERGENCY CONTACT RELATIONSHIP\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_EMERGENCY_CONTACT_NAME + "Sarah Lim "
             + PREFIX_EMERGENCY_CONTACT_PHONE + "91234567 "

--- a/src/main/java/seedu/address/model/person/EmergencyContact.java
+++ b/src/main/java/seedu/address/model/person/EmergencyContact.java
@@ -97,6 +97,6 @@ public class EmergencyContact {
 
     @Override
     public String toString() {
-        return "Name: " + name + " Phone: " + phone + " Relationship: " + relationship + " ";
+        return "Name: " + name + " Phone: " + phone + " Relationship: " + relationship;
     }
 }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -112,7 +112,7 @@ public class Person {
      */
     public Boolean hasEmergencyContact(EmergencyContact emergencyContactToCheck) {
         for (EmergencyContact emergencyContact : emergencyContacts) {
-            if (emergencyContact.equals((emergencyContactToCheck))) {
+            if (emergencyContact.isSamePerson((emergencyContactToCheck))) {
                 return true;
             }
         }

--- a/src/main/java/seedu/address/ui/EmergencyContactListPanel.java
+++ b/src/main/java/seedu/address/ui/EmergencyContactListPanel.java
@@ -29,6 +29,10 @@ public class EmergencyContactListPanel extends UiPart<Region> {
         emergencyContactListView.setCellFactory(listView -> new EmergencyContactListViewCell());
     }
 
+    public ListView<EmergencyContact> getEmergencyContactListView() {
+        return emergencyContactListView;
+    }
+
     /**
      * Custom {@code ListCell} that displays the graphics of a {@code EmergencyContact}
      * using a {@code EmergencyContactCard}.

--- a/src/main/java/seedu/address/ui/EmergencyContactSelectionController.java
+++ b/src/main/java/seedu/address/ui/EmergencyContactSelectionController.java
@@ -12,59 +12,13 @@ import seedu.address.model.person.Person;
 
 public class EmergencyContactSelectionController {
     private final List<ListView<EmergencyContact>> emergencyContactListViews = new ArrayList<>();
-    private final Map<ListView<EmergencyContact>, ListCell<Person>> viewCellMap = new HashMap<>();
-    private final Map<ListCell<Person>, ListView<EmergencyContact>> cellViewMap = new HashMap<>();
-    private List<ListCell<Person>> personListCells = new ArrayList<>();
-
-    private ListView<Person> personListView;
-
-    public EmergencyContactSelectionController(ListView<Person> personListView) {
-        personListView = personListView;
-    }
-
-    public void addPerson(ListCell<Person> personListCell, ListView<EmergencyContact> emergencyContactListView) {
-        addEmergencyContactListView(emergencyContactListView);
-        addPersonListCell(personListCell);
-        viewCellMap.put(emergencyContactListView, personListCell);
-        cellViewMap.put(personListCell, emergencyContactListView);
-    }
-
-    public void removePerson(ListView<EmergencyContact> emergencyContactListView) {
-        ListCell<Person> personListCellToDelete = viewCellMap.get(emergencyContactListView);
-        removePersonListCell(personListCellToDelete);
-        removeEmergencyContactListView(emergencyContactListView);
-        viewCellMap.remove(emergencyContactListView);
-        cellViewMap.remove(personListCellToDelete);
-    }
-
-    private void addEmergencyContactListView(ListView<EmergencyContact> emergencyContactListView) {
+    public void addEmergencyContactListView(ListView<EmergencyContact> emergencyContactListView) {
         emergencyContactListViews.add(emergencyContactListView);
         setupEmergencyContactSelectionListener(emergencyContactListView);
     }
 
-    private void removeEmergencyContactListView(ListView<EmergencyContact> emergencyContactListView) {
+    public void removeEmergencyContactListView(ListView<EmergencyContact> emergencyContactListView) {
         emergencyContactListViews.remove(emergencyContactListView);
-    }
-
-    private void addPersonListCell(ListCell<Person> personListCell) {
-        personListCells.add(personListCell);
-    }
-
-    private void removePersonListCell(ListCell<Person> personListCell) {
-        personListCells.remove(personListCell);
-    }
-
-    public void onListCellSelected(ListCell<Person> selectedCell) {
-        clearOtherSelections(selectedCell);
-    }
-
-    private void clearOtherSelections(ListCell<Person> selectedCell) {
-        ListView<EmergencyContact> targetEmergencyContactListView = cellViewMap.get(selectedCell);
-        for (ListView<EmergencyContact> emergencyContactListView : emergencyContactListViews) {
-            if (emergencyContactListView != targetEmergencyContactListView) {
-                emergencyContactListView.getSelectionModel().clearSelection();
-            }
-        }
     }
 
     private void setupEmergencyContactSelectionListener(ListView<EmergencyContact> emergencyContactListView) {
@@ -78,15 +32,6 @@ public class EmergencyContactSelectionController {
                         otherEmergencyContactListView.getSelectionModel().clearSelection();
                     }
                 }
-//                ListCell<Person> personListCell = viewCellMap.get(emergencyContactListView);
-////                personListView.getSelectionModel().select(personListCell.getIndex());
-//                personListCell.updateSelected(true);
-////                personListCell.getListView().getSelectionModel().select(personListCell.getIndex());
-//                for (ListCell<Person> otherPersonListCell : personListCells) {
-//                    otherPersonListCell.updateSelected(false);
-////                    otherPersonListCell.getListView().getSelectionModel().clearSelection(
-////                            otherPersonListCell.getIndex());
-//                }
             }
         });
     }

--- a/src/main/java/seedu/address/ui/EmergencyContactSelectionController.java
+++ b/src/main/java/seedu/address/ui/EmergencyContactSelectionController.java
@@ -1,23 +1,73 @@
 package seedu.address.ui;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.control.SelectionMode;
 import seedu.address.model.person.EmergencyContact;
+import seedu.address.model.person.Person;
 
 public class EmergencyContactSelectionController {
     private final List<ListView<EmergencyContact>> emergencyContactListViews = new ArrayList<>();
-    public void addEmergencyContactListView(ListView<EmergencyContact> emergencyContactListView) {
-        emergencyContactListViews.add(emergencyContactListView);
-        setupSelectionListener(emergencyContactListView);
+    private final Map<ListView<EmergencyContact>, ListCell<Person>> viewCellMap = new HashMap<>();
+    private final Map<ListCell<Person>, ListView<EmergencyContact>> cellViewMap = new HashMap<>();
+    private List<ListCell<Person>> personListCells = new ArrayList<>();
+
+    private ListView<Person> personListView;
+
+    public EmergencyContactSelectionController(ListView<Person> personListView) {
+        personListView = personListView;
     }
 
-    public void removeEmergencyContactListView(ListView<EmergencyContact> emergencyContactListView) {
+    public void addPerson(ListCell<Person> personListCell, ListView<EmergencyContact> emergencyContactListView) {
+        addEmergencyContactListView(emergencyContactListView);
+        addPersonListCell(personListCell);
+        viewCellMap.put(emergencyContactListView, personListCell);
+        cellViewMap.put(personListCell, emergencyContactListView);
+    }
+
+    public void removePerson(ListView<EmergencyContact> emergencyContactListView) {
+        ListCell<Person> personListCellToDelete = viewCellMap.get(emergencyContactListView);
+        removePersonListCell(personListCellToDelete);
+        removeEmergencyContactListView(emergencyContactListView);
+        viewCellMap.remove(emergencyContactListView);
+        cellViewMap.remove(personListCellToDelete);
+    }
+
+    private void addEmergencyContactListView(ListView<EmergencyContact> emergencyContactListView) {
+        emergencyContactListViews.add(emergencyContactListView);
+        setupEmergencyContactSelectionListener(emergencyContactListView);
+    }
+
+    private void removeEmergencyContactListView(ListView<EmergencyContact> emergencyContactListView) {
         emergencyContactListViews.remove(emergencyContactListView);
     }
 
-    private void setupSelectionListener(ListView<EmergencyContact> emergencyContactListView) {
+    private void addPersonListCell(ListCell<Person> personListCell) {
+        personListCells.add(personListCell);
+    }
+
+    private void removePersonListCell(ListCell<Person> personListCell) {
+        personListCells.remove(personListCell);
+    }
+
+    public void onListCellSelected(ListCell<Person> selectedCell) {
+        clearOtherSelections(selectedCell);
+    }
+
+    private void clearOtherSelections(ListCell<Person> selectedCell) {
+        ListView<EmergencyContact> targetEmergencyContactListView = cellViewMap.get(selectedCell);
+        for (ListView<EmergencyContact> emergencyContactListView : emergencyContactListViews) {
+            if (emergencyContactListView != targetEmergencyContactListView) {
+                emergencyContactListView.getSelectionModel().clearSelection();
+            }
+        }
+    }
+
+    private void setupEmergencyContactSelectionListener(ListView<EmergencyContact> emergencyContactListView) {
         emergencyContactListView.getSelectionModel().setSelectionMode(SelectionMode.SINGLE);
 
         emergencyContactListView.getSelectionModel().selectedItemProperty().addListener((obs, oldVal, newVal) -> {
@@ -28,6 +78,15 @@ public class EmergencyContactSelectionController {
                         otherEmergencyContactListView.getSelectionModel().clearSelection();
                     }
                 }
+//                ListCell<Person> personListCell = viewCellMap.get(emergencyContactListView);
+////                personListView.getSelectionModel().select(personListCell.getIndex());
+//                personListCell.updateSelected(true);
+////                personListCell.getListView().getSelectionModel().select(personListCell.getIndex());
+//                for (ListCell<Person> otherPersonListCell : personListCells) {
+//                    otherPersonListCell.updateSelected(false);
+////                    otherPersonListCell.getListView().getSelectionModel().clearSelection(
+////                            otherPersonListCell.getIndex());
+//                }
             }
         });
     }

--- a/src/main/java/seedu/address/ui/EmergencyContactSelectionController.java
+++ b/src/main/java/seedu/address/ui/EmergencyContactSelectionController.java
@@ -1,0 +1,34 @@
+package seedu.address.ui;
+import java.util.ArrayList;
+import java.util.List;
+
+import javafx.scene.control.ListView;
+import javafx.scene.control.SelectionMode;
+import seedu.address.model.person.EmergencyContact;
+
+public class EmergencyContactSelectionController {
+    private final List<ListView<EmergencyContact>> emergencyContactListViews = new ArrayList<>();
+    public void addEmergencyContactListView(ListView<EmergencyContact> emergencyContactListView) {
+        emergencyContactListViews.add(emergencyContactListView);
+        setupSelectionListener(emergencyContactListView);
+    }
+
+    public void removeEmergencyContactListView(ListView<EmergencyContact> emergencyContactListView) {
+        emergencyContactListViews.remove(emergencyContactListView);
+    }
+
+    private void setupSelectionListener(ListView<EmergencyContact> emergencyContactListView) {
+        emergencyContactListView.getSelectionModel().setSelectionMode(SelectionMode.SINGLE);
+
+        emergencyContactListView.getSelectionModel().selectedItemProperty().addListener((obs, oldVal, newVal) -> {
+            if (newVal != null) {
+                // Clear selection in other ListViews
+                for (ListView<EmergencyContact> otherEmergencyContactListView : emergencyContactListViews) {
+                    if (otherEmergencyContactListView != emergencyContactListView) {
+                        otherEmergencyContactListView.getSelectionModel().clearSelection();
+                    }
+                }
+            }
+        });
+    }
+}

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -5,10 +5,13 @@ import java.util.Comparator;
 import javafx.collections.FXCollections;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
+import javafx.scene.control.ListView;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
+import javafx.scene.layout.VBox;
+import seedu.address.model.person.EmergencyContact;
 import seedu.address.model.person.Person;
 
 /**
@@ -51,6 +54,8 @@ public class PersonCard extends UiPart<Region> {
     private Label doctorEmail;
     @FXML
     private FlowPane tags;
+    @FXML
+    private VBox emergencyContactsBox;
 
     /**
      * Creates a {@code PersonCode} with the given {@code Person} and index to display.
@@ -66,6 +71,14 @@ public class PersonCard extends UiPart<Region> {
 
         emergencyContactListPanel = new EmergencyContactListPanel(
                 FXCollections.observableArrayList(person.getEmergencyContacts()));
+
+        // Follows syntax of personCard, odd here refers to the displayedIndex - 1 i.e. zero-indexed list
+        if (displayedIndex % 2 == 0) {
+            emergencyContactsBox.getStyleClass().add("emergencyContactListView-odd");
+        } else {
+            emergencyContactsBox.getStyleClass().add("emergencyContactListView-even");
+        }
+
         emergencyContactListPanelPlaceholder.getChildren().add(emergencyContactListPanel.getRoot());
         // 90 is the height of 1 EmergencyContactHeight. Will update in future to make this dynamic
         // instead of hard-coded.
@@ -77,5 +90,9 @@ public class PersonCard extends UiPart<Region> {
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+    }
+
+    public ListView<EmergencyContact> getEmergencyContactListView() {
+        return emergencyContactListPanel.getEmergencyContactListView();
     }
 }

--- a/src/main/java/seedu/address/ui/PersonListPanel.java
+++ b/src/main/java/seedu/address/ui/PersonListPanel.java
@@ -25,7 +25,7 @@ public class PersonListPanel extends UiPart<Region> {
      */
     public PersonListPanel(ObservableList<Person> personList) {
         super(FXML);
-        emergencyContactSelectionController = new EmergencyContactSelectionController();
+        emergencyContactSelectionController = new EmergencyContactSelectionController(personListView);
         personListView.setItems(personList);
         personListView.setCellFactory(listView -> new PersonListViewCell());
     }
@@ -41,7 +41,7 @@ public class PersonListPanel extends UiPart<Region> {
 
             if (empty || person == null) {
                 if (personCard != null) {
-                    emergencyContactSelectionController.removeEmergencyContactListView(
+                    emergencyContactSelectionController.removePerson(
                             personCard.getEmergencyContactListView());
                 }
                 setGraphic(null);
@@ -50,8 +50,13 @@ public class PersonListPanel extends UiPart<Region> {
             } else {
                 personCard = new PersonCard(person, getIndex() + 1);
                 setGraphic(personCard.getRoot());
-                emergencyContactSelectionController.addEmergencyContactListView(
+                emergencyContactSelectionController.addPerson(this,
                         personCard.getEmergencyContactListView());
+                this.selectedProperty().addListener((obs, wasSelected, isSelected) -> {
+                    if (isSelected) {
+                        emergencyContactSelectionController.onListCellSelected(this);
+                    }
+                });
             }
         }
     }

--- a/src/main/java/seedu/address/ui/PersonListPanel.java
+++ b/src/main/java/seedu/address/ui/PersonListPanel.java
@@ -16,7 +16,7 @@ import seedu.address.model.person.Person;
 public class PersonListPanel extends UiPart<Region> {
     private static final String FXML = "PersonListPanel.fxml";
     private final Logger logger = LogsCenter.getLogger(PersonListPanel.class);
-
+    private final EmergencyContactSelectionController emergencyContactSelectionController;
     @FXML
     private ListView<Person> personListView;
 
@@ -25,6 +25,7 @@ public class PersonListPanel extends UiPart<Region> {
      */
     public PersonListPanel(ObservableList<Person> personList) {
         super(FXML);
+        emergencyContactSelectionController = new EmergencyContactSelectionController();
         personListView.setItems(personList);
         personListView.setCellFactory(listView -> new PersonListViewCell());
     }
@@ -33,15 +34,24 @@ public class PersonListPanel extends UiPart<Region> {
      * Custom {@code ListCell} that displays the graphics of a {@code Person} using a {@code PersonCard}.
      */
     class PersonListViewCell extends ListCell<Person> {
+        PersonCard personCard;
         @Override
         protected void updateItem(Person person, boolean empty) {
             super.updateItem(person, empty);
 
             if (empty || person == null) {
+                if (personCard != null) {
+                    emergencyContactSelectionController.removeEmergencyContactListView(
+                            personCard.getEmergencyContactListView());
+                }
                 setGraphic(null);
                 setText(null);
+                personCard = null;
             } else {
-                setGraphic(new PersonCard(person, getIndex() + 1).getRoot());
+                personCard = new PersonCard(person, getIndex() + 1);
+                setGraphic(personCard.getRoot());
+                emergencyContactSelectionController.addEmergencyContactListView(
+                        personCard.getEmergencyContactListView());
             }
         }
     }

--- a/src/main/java/seedu/address/ui/PersonListPanel.java
+++ b/src/main/java/seedu/address/ui/PersonListPanel.java
@@ -25,7 +25,7 @@ public class PersonListPanel extends UiPart<Region> {
      */
     public PersonListPanel(ObservableList<Person> personList) {
         super(FXML);
-        emergencyContactSelectionController = new EmergencyContactSelectionController(personListView);
+        emergencyContactSelectionController = new EmergencyContactSelectionController();
         personListView.setItems(personList);
         personListView.setCellFactory(listView -> new PersonListViewCell());
     }
@@ -41,7 +41,7 @@ public class PersonListPanel extends UiPart<Region> {
 
             if (empty || person == null) {
                 if (personCard != null) {
-                    emergencyContactSelectionController.removePerson(
+                    emergencyContactSelectionController.removeEmergencyContactListView(
                             personCard.getEmergencyContactListView());
                 }
                 setGraphic(null);
@@ -50,13 +50,8 @@ public class PersonListPanel extends UiPart<Region> {
             } else {
                 personCard = new PersonCard(person, getIndex() + 1);
                 setGraphic(personCard.getRoot());
-                emergencyContactSelectionController.addPerson(this,
+                emergencyContactSelectionController.addEmergencyContactListView(
                         personCard.getEmergencyContactListView());
-                this.selectedProperty().addListener((obs, wasSelected, isSelected) -> {
-                    if (isSelected) {
-                        emergencyContactSelectionController.onListCellSelected(this);
-                    }
-                });
             }
         }
     }

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -116,6 +116,14 @@
     -fx-border-width: 1;
 }
 
+.emergencyContactListView-odd {
+    -fx-background-color: #3c3e3f;
+}
+
+.emergencyContactListView-even {
+    -fx-background-color: #515658;
+}
+
 #emergencyContactListView .list-cell {
     -fx-label-padding: 0 0 0 0;
     -fx-graphic-text-gap : 0;

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -32,12 +32,19 @@
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
-      <VBox xmlns:fx="http://javafx.com/fxml/1" alignment="TOP_LEFT" xmlns="http://javafx.com/javafx/17">
+      <Region VBox.vgrow="NEVER" prefHeight="10" />
+      <VBox xmlns:fx="http://javafx.com/fxml/1" fx:id="emergencyContactsBox" alignment="TOP_LEFT" xmlns="http://javafx.com/javafx/17">
         <padding>
-          <Insets top="10" right="10" bottom="10" left="10" />
+          <Insets top="10" right="10" bottom="15" left="10" />
         </padding>
-        <StackPane fx:id="emergencyContactListPanelPlaceholder" maxHeight="180" VBox.vgrow="ALWAYS" />
+        <Label styleClass="cell_big_label" text="Emergency contacts:">
+          <VBox.margin>
+            <Insets bottom="10" /> <!-- Adds padding below the label -->
+          </VBox.margin>
+        </Label>
+        <StackPane fx:id="emergencyContactListPanelPlaceholder" maxHeight="180" VBox.vgrow="ALWAYS"/>
       </VBox>
+      <Region VBox.vgrow="NEVER" prefHeight="10" />
       <Label fx:id="doctorName" styleClass="doctor" text="\$doctorName" />
       <Label fx:id="doctorPhone" styleClass="doctor" text="\$doctorPhone" />
       <Label fx:id="doctorEmail" styleClass="doctor" text="\$doctorEmail" />


### PR DESCRIPTION
The selection of emergency contact cards belonging to a person will clear the selection of emergency contact cards belonging to other people.

This makes the selection of emergency contact cards independent of the selection of person cards.

However, I found it impossible to get rid of the bug where selecting the person card corresponding to the current selected emergency contact card deselects the emergency contact card as well. 😢 😢

Closes #87 Closes #85 